### PR TITLE
upgrade to go 1.20.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,13 +43,10 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install linter
-      run: |
-        cd /usr/local/bin
-        curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v1.49.0/golangci-lint-1.49.0-linux-amd64.tar.gz \
-          | tar xvz golangci-lint-1.49.0-linux-amd64/golangci-lint --strip-components=1
-    - name: Run linter
-      run: make lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52.2
 
   build-image:
     needs: [test-unit, lint]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.3-bullseye
+      image: golang:1.20.4-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.3-bullseye
+      image: golang:1.20.4-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,44 +1,40 @@
 run:
-  concurrency: 1
+  go: "1.20"
   deadline: 10m
-  skip-files:
-  - api/.*/groupversion_info.go
 
 linters:
   disable-all: true
   enable:
-  # - bodyclose # Not yet working with Go 1.18
+  - bodyclose
   - depguard
-  # - dupl
   - errcheck
   - exportloopref
   - forcetypeassert
+  - gci
   - goconst
-  - gocyclo
   - gofmt
   - goimports
   - gosec
+  - gosimple
   - govet
+  - ineffassign
   - lll
-  # - maligned
   - misspell
   - nakedret
-  - prealloc
   - revive
+  - staticcheck
+  - typecheck
   - unconvert
-  # - unparam # Not yet working with Go 1.18
-  # - unused # Not yet working with Go 1.18
+  - unparam
+  - unused
 
-# all available settings for all linters
+# all available settings for linters we enable
 linters-settings:
   depguard:
     list-type: blacklist
     include-go-root: false
     packages:
     - github.com/davecgh/go-spew/spew
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.
@@ -47,14 +43,20 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: false
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/akuity)
+      - dot
+      - blank
+    skip-generated: true
+    custom-order: true
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3
     # minimal occurrences count to trigger, 3 by default
     min-occurrences: 3
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 20
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -82,15 +84,6 @@ linters-settings:
   nakedret:
     # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
     max-func-lines: 30
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
   unparam:
     # call graph construction algorithm (cha, rta). In general, use cha for libraries,
     # and rta for programs with main packages. Default is cha.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.3-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.4-bullseye as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM golang:1.20.4-bullseye
 
 ARG TARGETARCH
 
-ARG GOLANGCI_LINT_VERSION=1.49.0
+ARG GOLANGCI_LINT_VERSION=1.52.2
 
 RUN cd /usr/local/bin \
     && curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-bullseye
+FROM golang:1.20.4-bullseye
 
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SHELL ?= /bin/bash
 
 .PHONY: lint
 lint:
-	golangci-lint run --config golangci.yaml
+	golangci-lint run
 
 .PHONY: test-unit
 test-unit:

--- a/branches_test.go
+++ b/branches_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akuity/bookkeeper/internal/file"
 	"github.com/stretchr/testify/require"
+
+	"github.com/akuity/bookkeeper/internal/file"
 )
 
 func TestLoadBranchMetadata(t *testing.T) {

--- a/cmd/cli/render_cmd.go
+++ b/cmd/cli/render_cmd.go
@@ -87,7 +87,7 @@ func newRenderCommand() (*cobra.Command, error) {
 	return cmd, nil
 }
 
-func runRenderCmd(cmd *cobra.Command, args []string) error {
+func runRenderCmd(cmd *cobra.Command, _ []string) error {
 	req := bookkeeper.RenderRequest{}
 	var err error
 	req.Images, err = cmd.Flags().GetStringArray(flagImage)

--- a/cmd/cli/version_cmd.go
+++ b/cmd/cli/version_cmd.go
@@ -18,7 +18,7 @@ func newVersionCommand() *cobra.Command {
 	return cmd
 }
 
-func runVersionCommand(cmd *cobra.Command, args []string) error {
+func runVersionCommand(cmd *cobra.Command, _ []string) error {
 	clientVersion := version.GetVersion()
 
 	outputFormat, err := cmd.Flags().GetString(flagOutput)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/akuity/bookkeeper/cmd/action"
 	"github.com/akuity/bookkeeper/cmd/cli"
-	log "github.com/sirupsen/logrus"
 )
 
 const binaryNameEnvVar = "BOOKKEEPER_BINARY_NAME"

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package bookkeeper
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"github.com/akuity/bookkeeper/internal/helm"
 	"github.com/akuity/bookkeeper/internal/kustomize"
 	"github.com/akuity/bookkeeper/internal/ytt"
+
+	_ "embed"
 )
 
 //go:embed schema.json

--- a/config_test.go
+++ b/config_test.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/akuity/bookkeeper/internal/helm"
 	"github.com/akuity/bookkeeper/internal/kustomize"
 	"github.com/akuity/bookkeeper/internal/ytt"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLoadRepoConfig(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -1,8 +1,9 @@
 package bookkeeper
 
 import (
-	"github.com/akuity/bookkeeper/internal/git"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/akuity/bookkeeper/internal/git"
 )
 
 type renderRequestContext struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/akuity/bookkeeper
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -93,7 +92,6 @@ type repo struct {
 // perform any setup that is required for successfully authenticating to the
 // remote repository.
 func Clone(
-	ctx context.Context,
 	url string,
 	repoCreds RepoCredentials,
 ) (Repo, error) {
@@ -110,14 +108,14 @@ func Clone(
 		homeDir: homeDir,
 		dir:     filepath.Join(homeDir, "repo"),
 	}
-	if err = r.setupAuth(ctx, repoCreds); err != nil {
+	if err = r.setupAuth(repoCreds); err != nil {
 		return nil, err
 	}
 	return r, r.clone()
 }
 
 func (r *repo) AddAll() error {
-	_, err := libExec.Exec(r.buildCommand("git", "add", "."))
+	_, err := libExec.Exec(r.buildCommand("add", "."))
 	return errors.Wrap(err, "error staging changes for commit")
 }
 
@@ -129,19 +127,13 @@ func (r *repo) AddAllAndCommit(message string) error {
 }
 
 func (r *repo) Clean() error {
-	_, err := libExec.Exec(r.buildCommand("git", "clean", "-fd"))
+	_, err := libExec.Exec(r.buildCommand("clean", "-fd"))
 	return errors.Wrapf(err, "error cleaning branch %q", r.currentBranch)
 }
 
 func (r *repo) clone() error {
 	r.currentBranch = "HEAD"
-	cmd := r.buildCommand(
-		"git",
-		"clone",
-		"--no-tags",
-		r.url,
-		r.dir,
-	)
+	cmd := r.buildCommand("clone", "--no-tags", r.url, r.dir)
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	_, err := libExec.Exec(cmd)
 	return errors.Wrapf(
@@ -159,7 +151,6 @@ func (r *repo) Close() error {
 func (r *repo) Checkout(branch string) error {
 	r.currentBranch = branch
 	_, err := libExec.Exec(r.buildCommand(
-		"git",
 		"checkout",
 		branch,
 		// The next line makes it crystal clear to git that we're checking out
@@ -176,7 +167,7 @@ func (r *repo) Checkout(branch string) error {
 }
 
 func (r *repo) Commit(message string) error {
-	_, err := libExec.Exec(r.buildCommand("git", "commit", "-m", message))
+	_, err := libExec.Exec(r.buildCommand("commit", "-m", message))
 	return errors.Wrapf(
 		err,
 		"error committing changes to branch %q",
@@ -187,7 +178,6 @@ func (r *repo) Commit(message string) error {
 func (r *repo) CreateChildBranch(branch string) error {
 	r.currentBranch = branch
 	_, err := libExec.Exec(r.buildCommand(
-		"git",
 		"checkout",
 		"-b",
 		branch,
@@ -207,7 +197,6 @@ func (r *repo) CreateChildBranch(branch string) error {
 func (r *repo) CreateOrphanedBranch(branch string) error {
 	r.currentBranch = branch
 	if _, err := libExec.Exec(r.buildCommand(
-		"git",
 		"switch",
 		"--orphan",
 		branch,
@@ -224,20 +213,20 @@ func (r *repo) CreateOrphanedBranch(branch string) error {
 }
 
 func (r *repo) HasDiffs() (bool, error) {
-	resBytes, err := libExec.Exec(r.buildCommand("git", "status", "-s"))
+	resBytes, err := libExec.Exec(r.buildCommand("status", "-s"))
 	return len(resBytes) > 0,
 		errors.Wrapf(err, "error checking status of branch %q", r.currentBranch)
 }
 
 func (r *repo) LastCommitID() (string, error) {
-	shaBytes, err := libExec.Exec(r.buildCommand("git", "rev-parse", "HEAD"))
+	shaBytes, err := libExec.Exec(r.buildCommand("rev-parse", "HEAD"))
 	return strings.TrimSpace(string(shaBytes)),
 		errors.Wrap(err, "error obtaining ID of last commit")
 }
 
 func (r *repo) CommitMessage(id string) (string, error) {
 	msgBytes, err := libExec.Exec(
-		r.buildCommand("git", "log", "-n", "1", "--pretty=format:%s", id),
+		r.buildCommand("log", "-n", "1", "--pretty=format:%s", id),
 	)
 	return string(msgBytes),
 		errors.Wrapf(err, "error obtaining commit message for commit %q", id)
@@ -245,7 +234,6 @@ func (r *repo) CommitMessage(id string) (string, error) {
 
 func (r *repo) CommitMessages(id1, id2 string) ([]string, error) {
 	allMsgBytes, err := libExec.Exec(r.buildCommand(
-		"git",
 		"log",
 		"--pretty=oneline",
 		"--decorate-refs=",
@@ -276,13 +264,12 @@ func (r *repo) CommitMessages(id1, id2 string) ([]string, error) {
 
 func (r *repo) Push() error {
 	_, err :=
-		libExec.Exec(r.buildCommand("git", "push", "origin", r.currentBranch))
+		libExec.Exec(r.buildCommand("push", "origin", r.currentBranch))
 	return errors.Wrapf(err, "error pushing branch %q", r.currentBranch)
 }
 
 func (r *repo) RemoteBranchExists(branch string) (bool, error) {
 	_, err := libExec.Exec(r.buildCommand(
-		"git",
 		"ls-remote",
 		"--heads",
 		"--exit-code", // Return 2 if not found
@@ -311,26 +298,15 @@ func (r *repo) WorkingDir() string {
 
 // SetupAuth configures the git CLI for authentication using either SSH or the
 // "store" (username/password-based) credential helper.
-func (r *repo) setupAuth(ctx context.Context, repoCreds RepoCredentials) error {
+func (r *repo) setupAuth(repoCreds RepoCredentials) error {
 	// Configure the git client
-	cmd := r.buildCommand(
-		"git",
-		"config",
-		"--global",
-		"user.name",
-		"Bookkeeper",
-	)
+	cmd := r.buildCommand("config", "--global", "user.name", "Bookkeeper")
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return errors.Wrapf(err, "error configuring git username")
 	}
-	cmd = r.buildCommand(
-		"git",
-		"config",
-		"--global",
-		"user.email",
-		"bookkeeper@akuity.io",
-	)
+	cmd =
+		r.buildCommand("config", "--global", "user.email", "bookkeeper@akuity.io")
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return errors.Wrapf(err, "error configuring git user email address")
@@ -360,8 +336,7 @@ func (r *repo) setupAuth(ctx context.Context, repoCreds RepoCredentials) error {
 	// If we get to here, we're authenticating using a password
 
 	// Set up the credential helper
-	cmd =
-		r.buildCommand("git", "config", "--global", "credential.helper", "store")
+	cmd = r.buildCommand("config", "--global", "credential.helper", "store")
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return errors.Wrapf(err, "error configuring git credential helper")
@@ -399,8 +374,8 @@ func (r *repo) setupAuth(ctx context.Context, repoCreds RepoCredentials) error {
 	return nil
 }
 
-func (r *repo) buildCommand(name string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(name, arg...)
+func (r *repo) buildCommand(arg ...string) *exec.Cmd {
+	cmd := exec.Command("git", arg...)
 	homeEnvVar := fmt.Sprintf("HOME=%s", r.homeDir)
 	if cmd.Env == nil {
 		cmd.Env = []string{homeEnvVar}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -3,13 +3,14 @@ package helm
 import (
 	"context"
 
-	"github.com/akuity/bookkeeper/internal/manifests"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/repository"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/akuity/bookkeeper/internal/manifests"
 )
 
 // Render delegates, in-process to the Argo CD repo server to render plain YAML

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/akuity/bookkeeper/internal/manifests"
-	"github.com/akuity/bookkeeper/internal/strings"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/repository"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/akuity/bookkeeper/internal/manifests"
+	"github.com/akuity/bookkeeper/internal/strings"
 )
 
 // Render delegates, in-process to the Argo CD repo server to render plain YAML

--- a/service.go
+++ b/service.go
@@ -75,7 +75,6 @@ func (s *service) RenderManifests(
 	}
 
 	if rc.repo, err = git.Clone(
-		ctx,
 		rc.request.RepoURL,
 		git.RepoCredentials{
 			SSHPrivateKey: rc.request.RepoCreds.SSHPrivateKey,

--- a/service_test.go
+++ b/service_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akuity/bookkeeper/internal/file"
 	"github.com/stretchr/testify/require"
+
+	"github.com/akuity/bookkeeper/internal/file"
 )
 
 func TestWriteAppManifests(t *testing.T) {


### PR DESCRIPTION
This also includes a linter upgrade, which seems to have been necessary when stepping up to Go 1.20, adopts the same linter rules as Kargo, and addresses any linter issues discovered.

There are no functional changes in this PR.