### PR TITLE
ignore metadata-only changes

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,7 +3,7 @@ package bookkeeper
 import (
 	log "github.com/sirupsen/logrus"
 
-	"github.com/akuity/bookkeeper/internal/git"
+	"github.com/akuity/bookkeeper/pkg/git"
 )
 
 type renderRequestContext struct {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 
-	"github.com/akuity/bookkeeper/internal/git"
+	"github.com/akuity/bookkeeper/pkg/git"
 )
 
 func OpenPR(

--- a/prs.go
+++ b/prs.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/akuity/bookkeeper/internal/git"
 	"github.com/akuity/bookkeeper/internal/github"
+	"github.com/akuity/bookkeeper/pkg/git"
 )
 
 func openPR(ctx context.Context, rc renderRequestContext) (string, error) {


### PR DESCRIPTION
Before this PR, it was possible for metadata-only commits to be made to environment-specific branches... which turns out to be a bit annoying.

This PR amends the commit process to analyze diffs and treat metadata-only changes as if there were no changes at all.

This PR _also_ moves the `git` package from `internal` (where it's not re-usable by others) to `pkg` (where it is), so that Kargo can drop its own `git` package and start using this one.