### PR TITLE
reduce noise in repo history

### DIFF
--- a/service.go
+++ b/service.go
@@ -299,34 +299,38 @@ func buildCommitMessage(rc renderRequestContext) (string, error) {
 		rc.source.commit,
 	)
 
-	// Find all recent commits
-	var memberCommitMsgs []string
-	if rc.target.oldBranchMetadata.SourceCommit != "" {
-		// Add info about member commits
-		formattedCommitMsg = fmt.Sprintf(
-			"%s\n\nThis includes the following changes (newest to oldest):",
-			formattedCommitMsg,
-		)
-		var err error
-		if memberCommitMsgs, err = rc.repo.CommitMessages(
-			rc.target.oldBranchMetadata.SourceCommit,
-			rc.source.commit,
-		); err != nil {
-			return "", errors.Wrapf(
-				err,
-				"error getting commit messages between commit %q and %q",
-				rc.target.oldBranchMetadata.SourceCommit,
-				rc.source.commit,
-			)
-		}
-		for _, memberCommitMsg := range memberCommitMsgs {
-			formattedCommitMsg = fmt.Sprintf(
-				"%s\n  * %s",
-				formattedCommitMsg,
-				memberCommitMsg,
-			)
-		}
-	}
+	// TODO: Tentatively removing the following because it simply results in too
+	// much noise in the repo history. Leaving it commented for now in case we
+	// decide to bring it back later.
+	//
+	// // Find all recent commits
+	// if rc.target.oldBranchMetadata.SourceCommit != "" {
+	// 	var memberCommitMsgs []string
+	// 	// Add info about member commits
+	// 	formattedCommitMsg = fmt.Sprintf(
+	// 		"%s\n\nThis includes the following changes (newest to oldest):",
+	// 		formattedCommitMsg,
+	// 	)
+	// 	var err error
+	// 	if memberCommitMsgs, err = rc.repo.CommitMessages(
+	// 		rc.target.oldBranchMetadata.SourceCommit,
+	// 		rc.source.commit,
+	// 	); err != nil {
+	// 		return "", errors.Wrapf(
+	// 			err,
+	// 			"error getting commit messages between commit %q and %q",
+	// 			rc.target.oldBranchMetadata.SourceCommit,
+	// 			rc.source.commit,
+	// 		)
+	// 	}
+	// 	for _, memberCommitMsg := range memberCommitMsgs {
+	// 		formattedCommitMsg = fmt.Sprintf(
+	// 			"%s\n  * %s",
+	// 			formattedCommitMsg,
+	// 			memberCommitMsg,
+	// 		)
+	// 	}
+	// }
 
 	if len(rc.target.newBranchMetadata.ImageSubstitutions) != 0 {
 		formattedCommitMsg = fmt.Sprintf(


### PR DESCRIPTION
This is a practical improvement discovered through our dogfooding.

Previous to this PR, the logic for building commit messages was this:

1. Let x represent the commit ID that the last env-specific render was based on (this comes from env/branch-specific metadata)
1. Let x' represent the commit ID you're now rendering from
1. Always use x' as the first line of the commit
1. If x != "", add all commit messages between x (last render source) and x' (current render source) into the new commit message
1. End the new commit message with a note that Bookkeeper generated this commit by rendering from x' (current render source)

_Step 4 turns out to be overkill_. When things are automated (and Bookkeeper is meant to be automated), step 4 never yields anything _unless_ there is a PR involved and that PR is being amended with new commits. In this scenario, we end up with two problems:

1. Each new commit gets a progressively longer message, containing not only its _own_ message, but every message that came between x and x'. If care isn't taken by the user who merges the PR to cut redundant messages from the merge commit, or if a merge commit isn't used at all, this can result in extremely noisy (to the point of uselessness) history in the repo.

1. Some commits between x and x' may not even have affected the env-specific branch we're rendering _to_ and we wouldn't want those in the history of that env-specific branch.

Experimentation shows things are more orderly on the whole if we just cut step 4 out of the equation. As long as things are automated, there's no loss of information by doing this and the signal-to-noise ratio becomes much better.