### PR TITLE
make bookkeeper action use upcoming release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,5 +9,5 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/akuity/bookkeeper:v0.1.0-alpha.2-rc.17
+  image: docker://ghcr.io/akuity/bookkeeper:v0.1.0-rc.18
   entrypoint: bookkeeper-action


### PR DESCRIPTION
Planning to cut another RC that will further reduce noise wherever we are dogfooding this. This PR updates the action definition in advance so that the action will reference the correct image.

Reminder that we'll figure out a way to automate this eventually: https://github.com/akuity/bookkeeper/issues/150