### PR TITLE
Added Governance bot closes #159

### DIFF
--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -1,0 +1,41 @@
+# Documentation: https://github.com/BirthdayResearch/oss-governance-bot
+version: v1
+
+issue:
+  labels:
+    - prefix: kind
+      list:
+        - feature
+        - bug
+        - refactor
+        - enhancement
+      multiple: true
+      needs: true
+
+    - prefix: priority
+      list:
+        - urgent
+        - high
+        - normal
+        - low
+      multiple: false
+      needs: true
+
+    - prefix: area
+      list:
+        # generic areas
+        - chore
+        - planning
+        - devx
+        - documentation
+        - perf
+        - regression
+        - security
+        - tech-debt
+        - test
+        - ux
+        - ci-process
+        - release-process
+        # bookkeeper component areas
+      multiple: true
+      needs: true

--- a/.github/workflows/governance.yaml
+++ b/.github/workflows/governance.yaml
@@ -1,0 +1,18 @@
+# Documentation: https://github.com/BirthdayResearch/oss-governance-bot
+on:
+    pull_request_target:
+      types: [ synchronize, opened, labeled, unlabeled ]
+    issues:
+      types: [ opened, labeled, unlabeled ]
+    issue_comment:
+      types: [ created ]
+
+jobs:
+    governance:
+        name: Governance
+        runs-on: ubuntu-latest
+        steps:
+            - uses: BirthdayResearch/oss-governance-bot@v3
+              with:
+                config-path: .github/governance.yml
+    


### PR DESCRIPTION
Added the Governance bot similar to Kargo.

It still needs the Bookkeeper specific `area`'s defined, but that can be done with a follow-up PR.

closes #159 