### PR TITLE
remove kind/feature label from governance bot

### DIFF
--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -5,7 +5,6 @@ issue:
   labels:
     - prefix: kind
       list:
-        - feature
         - bug
         - refactor
         - enhancement


### PR DESCRIPTION
This label seems to overlap entirely with kind/enhancement.