### PR TITLE
upgrade linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.2
+        version: v1.53.3
 
   build-image:
     needs: [test-unit, lint]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ linters:
   disable-all: true
   enable:
   - bodyclose
-  - depguard
   - errcheck
   - exportloopref
   - forcetypeassert
@@ -30,11 +29,6 @@ linters:
 
 # all available settings for linters we enable
 linters-settings:
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-    - github.com/davecgh/go-spew/spew
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM golang:1.20.4-bullseye
 
 ARG TARGETARCH
 
-ARG GOLANGCI_LINT_VERSION=1.52.2
+ARG GOLANGCI_LINT_VERSION=1.53.3
 
 RUN cd /usr/local/bin \
     && curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz \


### PR DESCRIPTION
This PR upgrades the golangci-linter and disables the depguard linter, which has breaking changes. It's usefulness is so small that it doesn't warrant fixing its configuration.