### PR TITLE
Update action definition to reference upcoming release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,5 +9,5 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/akuity/bookkeeper:v0.1.0-rc.18
+  image: docker://ghcr.io/akuity/bookkeeper:v0.1.0-rc.20
   entrypoint: bookkeeper-action


### PR DESCRIPTION
The rc.19 action still references the buggy rc.18 image.

After this is merged, we'll cut an rc.20.

Note there is already an issue open to automate this process.