### PR TITLE
return error instead of panicking upon branch hijacking

### DIFF
--- a/service.go
+++ b/service.go
@@ -157,6 +157,13 @@ func (s *service) RenderManifests(
 	if err != nil {
 		return res, errors.Wrap(err, "error loading branch metadata")
 	}
+	if oldTargetBranchMetadata == nil {
+		return res, errors.Errorf(
+			"target branch %q already exists, but does not appear to be managed by "+
+				"Bookkeeper; refusing to overwrite branch contents",
+			rc.request.TargetBranch,
+		)
+	}
 	rc.target.oldBranchMetadata = *oldTargetBranchMetadata
 
 	if rc.target.commit.branch, err = switchToCommitBranch(rc); err != nil {


### PR DESCRIPTION
Fixes #166

This will prevent the nil pointer dereference that currently occurs when Bookkeeper is asked to write to an existing branch that isn't already Bookkeeper-managed.

It will return an error instead, which seems like the most sensible thing to do, because this was probably a mistake on the user's part.

If you _do_ want Bookkeeper to take over an existing branch, you can either delete the target branch or manually `touch .bookkeeper/metadata.yaml` on the target branch.

cc @jessesuen @christianh814 this tripped up both of you (and me too) at some point in recent weeks.