### PR TITLE
doc: Fix Bookfile.yaml file name

### DIFF
--- a/docs/docs/30-how-to-guides/10-configuration.mdx
+++ b/docs/docs/30-how-to-guides/10-configuration.mdx
@@ -444,7 +444,7 @@ branchConfigs:
 
 ## Convention over configuration
 
-In the absence of a `Bookkeeper.yaml` file at the root of the default branch,
+In the absence of a `Bookfile.yaml` file at the root of the default branch,
 Bookkeeper will assume:
 
 * You are using [Kustomize](https://kustomize.io/) for configuration management.


### PR DESCRIPTION
Found one left-over reference to `Bookkeeper.yaml` - this sadly cost me an hour tonight ;-)