### PR TITLE
Support setting helm namespace in Bookfile

### DIFF
--- a/docs/docs/30-how-to-guides/10-configuration.mdx
+++ b/docs/docs/30-how-to-guides/10-configuration.mdx
@@ -199,6 +199,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: foo
+          namespace: foo #optional
           chartPath: charts/foo
           valuesPaths:
           - env/test/foo/values.yaml
@@ -207,6 +208,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: bar
+          namespace: bar #optional
           chartPath: charts/bar
           valuesPaths:
           - env/test/bar/values.yaml
@@ -217,6 +219,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: foo
+          namespace: foo #optional
           chartPath: charts/foo
           valuesPaths:
           - env/stage/foo/values.yaml
@@ -225,6 +228,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: bar
+          namespace: bar #optional
           chartPath: charts/bar
           valuesPaths:
           - env/stage/bar/values.yaml
@@ -235,6 +239,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: foo
+          namespace: foo #optional
           chartPath: charts/foo
           valuesPaths:
           - env/prod/foo/values.yaml
@@ -243,6 +248,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: bar
+          namespace: bar #optional
           chartPath: charts/bar
           valuesPaths:
           - env/prod/bar/values.yaml
@@ -332,6 +338,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: foo
+          namespace: foo #optional
           chartPath: charts/foo
           valuesPaths:
           - env/${1}/foo/values.yaml
@@ -340,6 +347,7 @@ branchConfigs:
       configManagement:
         helm:
           releaseName: bar
+          namespace: bar #optional
           chartPath: charts/bar
           valuesPaths:
           - env/${1}/bar/values.yaml

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	// `--values` flag in the `helm template` command. By convention, if left
 	// unspecified, one path will be assumed: <branch name>/values.yaml.
 	ValuesPaths []string `json:"valuesPaths,omitempty"`
+	// Namespace is the Kubernetes namespace in which the Helm chart will be
+	// rendered. This is used as an argument in the `helm template` command. By
+	// convention, if left unspecified, the value `default` is assumed.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // Expand expands all file/directory paths referenced by this configuration

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -18,6 +18,7 @@ import (
 func Render(
 	ctx context.Context,
 	releaseName string,
+	namespace string,
 	chartPath string,
 	valuesPaths []string,
 ) ([]byte, error) {
@@ -31,6 +32,7 @@ func Render(
 		"", // Repo root
 		"", // Revision
 		&apiclient.ManifestRequest{
+			Namespace: namespace,
 			// Both of these fields need to be non-nil
 			Repo: &argoappv1.Repository{},
 			ApplicationSource: &argoappv1.ApplicationSource{

--- a/rendering.go
+++ b/rendering.go
@@ -45,6 +45,7 @@ func (s *service) preRender(
 			appLogger = appLogger.WithFields(log.Fields{
 				"configManagement": "helm",
 				"releaseName":      appConfig.ConfigManagement.Helm.ReleaseName,
+				"namespace":        appConfig.ConfigManagement.Helm.Namespace,
 				"chartPath":        chartPath,
 				"valuesPaths":      valuesPaths,
 			})
@@ -56,6 +57,7 @@ func (s *service) preRender(
 			manifests[appName], err = s.helmRenderFn(
 				ctx,
 				appConfig.ConfigManagement.Helm.ReleaseName,
+				appConfig.ConfigManagement.Helm.Namespace,
 				chartPath,
 				absValuesPaths,
 			)

--- a/rendering_test.go
+++ b/rendering_test.go
@@ -42,6 +42,7 @@ func TestPreRender(t *testing.T) {
 					context.Context,
 					string,
 					string,
+					string,
 					[]string,
 				) ([]byte, error) {
 					return nil, errors.New("something went wrong")
@@ -70,6 +71,7 @@ func TestPreRender(t *testing.T) {
 			service: &service{
 				helmRenderFn: func(
 					context.Context,
+					string,
 					string,
 					string,
 					[]string,

--- a/schema.json
+++ b/schema.json
@@ -102,6 +102,10 @@
 					"type": "string",
 					"pattern": "^\\w[\\w-]*\\w$"
 				},
+				"namespace": {
+					"type": "string",
+					"pattern": "^\\w[\\w-]*\\w$"
+				},
 				"chartPath": {
 					"$ref": "#/definitions/relativePath"
 				},

--- a/service.go
+++ b/service.go
@@ -35,6 +35,7 @@ type service struct {
 	helmRenderFn func(
 		ctx context.Context,
 		releaseName string,
+		namespace string,
 		chartPath string,
 		valuesPaths []string,
 	) ([]byte, error)


### PR DESCRIPTION
### Summary
Introduces a new config option into `Bookfile.yaml` to set the helm namespace since some charts consume `.Release.Namespace` in their templates.


### Testing
If string is empty, reposerver will not append the `--namespace` parameter.

With namespace set

```
INFO[0001] Trace   args="[helm template . --name-template podinfo --namespace podinfo --values /tmp/4176594743/repo/chart/values-dev.yaml --include-crds]" dir=/tmp/4176594743/repo/chart operation_name="exec helm" time_ms=82.134863
```

Without
```
INFO[0002] Trace   args="[helm template . --name-template podinfo --values /tmp/876360118/repo/chart/values-dev.yaml --include-crds]" dir=/tmp/876360118/repo/chart operation_name="exec helm" time_ms=168.38142200000001
```

### Example config
```yaml
- pattern: env/(\w+)
  appConfigs:
    podinfo:
      configManagement:
        helm:
          releaseName: podinfo
          chartPath: chart
          namespace: podinfo
          valuesPaths:
          - chart/values-${1}.yaml
      outputPath: environments/${1}
```

### Note
I did contemplate adding it as a cli flag first, but this seemed better suited (since it's not expected to change dynamically).

### References
fixes #171