### PR TITLE
rename project to Kargo Render

### DIFF
--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -37,6 +37,6 @@ issue:
         - ux
         - ci-process
         - release-process
-        # bookkeeper component areas
+        # kargo-render component areas
       multiple: true
       needs: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: ghcr.io/akuity/bookkeeper
+        images: ghcr.io/akuity/kargo-render
         flavor: latest=false
         tags: type=semver,pattern={{raw}}
     - name: Build and push

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of conduct
 
-See https://bookkeeper.akuity.io/contributor-guide/code-of-conduct/
+See https://kargo-render.akuity.io/contributor-guide/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Bookkeeper contributor guide
+# Kargo Render contributor guide
 
-See https://bookkeeper.akuity.io/contributor-guide/
+See https://kargo-render.akuity.io/contributor-guide/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN curl -L -o /usr/local/bin/ytt \
       https://github.com/vmware-tanzu/carvel-ytt/releases/download/${YTT_VERSION}/ytt-linux-${TARGETARCH} \
       && chmod 755 /usr/local/bin/ytt
 
-ARG VERSION_PACKAGE=github.com/akuity/bookkeeper/internal/version
+ARG VERSION_PACKAGE=github.com/akuity/kargo-render/internal/version
 ARG CGO_ENABLED=0
 
-WORKDIR /bookkeeper
+WORKDIR /kargo-render
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
@@ -33,11 +33,11 @@ ARG GIT_TREE_STATE
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PACKAGE}.gitCommit=${GIT_COMMIT} -X ${VERSION_PACKAGE}.gitTreeState=${GIT_TREE_STATE}" \
-      -o bin/bookkeeper \
+      -o bin/kargo-render \
       ./cmd \
-    && bin/bookkeeper version \
+    && bin/kargo-render version \
     && cd bin \
-    && ln -s bookkeeper bookkeeper-action
+    && ln -s kargo-render kargo-render-action
 
 FROM alpine:3.15.4 as final
 
@@ -49,8 +49,8 @@ RUN apk update \
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/
 COPY --from=builder /usr/local/bin/ytt /usr/local/bin/
-COPY --from=builder /bookkeeper/bin/ /usr/local/bin/
+COPY --from=builder /kargo-render/bin/ /usr/local/bin/
 
 USER nonroot
 
-CMD ["/usr/local/bin/bookkeeper"]
+CMD ["/usr/local/bin/kargo-render"]

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ DOCKER_CMD := docker run \
 	-it \
 	--rm \
 	-v gomodcache:/go/pkg/mod \
-	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/bookkeeper \
-	-w /workspaces/bookkeeper \
-	bookkeeper:dev-tools
+	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/kargo-render \
+	-w /workspaces/kargo-render \
+	kargo-render:dev-tools
 
 .PHONY: hack-build-dev-tools
 hack-build-dev-tools:
-	docker build -f Dockerfile.dev -t bookkeeper:dev-tools .
+	docker build -f Dockerfile.dev -t kargo-render:dev-tools .
 
 .PHONY: hack-lint
 hack-lint: hack-build-dev-tools
@@ -57,5 +57,5 @@ hack-build:
 	docker build \
 		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 		--build-arg GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi) \
-		--tag bookkeeper:dev \
+		--tag kargo-render:dev \
 		.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,46 @@
-# Bookkeeper -- Environment Branches Utility
+# Kargo Render -- Rendered Branches Utility
 
-![CI](https://github.com/akuity/bookkeeper/actions/workflows/ci.yaml/badge.svg)
-[![codecov](https://codecov.io/gh/akuity/bookkeeper/branch/main/graph/badge.svg?token=MRKMA584M9)](https://codecov.io/gh/akuity/bookkeeper)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/f5d7d99b-ca3a-4477-a10b-67fb7a8328a9/deploy-status)](https://app.netlify.com/sites/docs-bookkeeper-akuity-io/deploys)
+![CI](https://github.com/akuity/kargo-render/actions/workflows/ci.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/akuity/kargo-render/branch/main/graph/badge.svg?token=MRKMA584M9)](https://codecov.io/gh/akuity/kargo-render)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/f5d7d99b-ca3a-4477-a10b-67fb7a8328a9/deploy-status)](https://app.netlify.com/sites/docs-kargo-render-akuity-io/deploys)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 <img width="80" align="left" src="logo.png" style="right-margin: 20px"/>
 
 Placeholder
 
-🟡&nbsp;&nbsp;Bookkeeper is highly experimental at this time and breaking
+🟡&nbsp;&nbsp;Kargo Render is highly experimental at this time and breaking
 changes should be anticipated between pre-GA minor releases.
 
 <br clear="left"/>
 
 ## Getting Started
 
-Read more about Bookkeeper in our [docs](https://bookkeeper.akuity.io).
+Read more about Kargo Render in our [docs](https://kargo-render.akuity.io).
 
 This documentation is very new, so please open issues against this repository if
 you encounter any difficulties with it.
 
 ## Roadmap
 
-Visit our [Roadmap](https://bookkeeper.akuity.io/roadmap) for frequently updated
-details about what we've accomplished so far and what we're currently working
-on.
+Visit our [Roadmap](https://kargo-render.akuity.io/roadmap) for frequently
+updated details about what we've accomplished so far and what we're currently
+working on.
 
 ## Contributing
 
-The Bookkeeper project accepts contributions via GitHub pull requests.
+The Kargo Render project accepts contributions via GitHub pull requests.
 
 Visit our
-[Bookkeeper Contributor Guide](https://bookkeeper.akuity.io/contributor-guide/)
+[Kargo Render Contributor Guide](https://kargo-render.akuity.io/contributor-guide/)
 for more info on how to get started quickly and easily.
 
 ## Support & Feedback
 
 To report an issue, request a feature, or ask a question, please open an issue
-[here](https://github.com/akuity/bookkeeper/issues).
+[here](https://github.com/akuity/kargo-render/issues).
 
 ## Code of Conduct
 
-Participation in the Bookkeeper project is governed by the
-[Contributor Covenant Code of Conduct](https://bookkeeper.akuity.io/contributor-guide/code-of-conduct/).
+Participation in the Kargo Render project is governed by the
+[Contributor Covenant Code of Conduct](https://kargo-render.akuity.io/contributor-guide/code-of-conduct/).

--- a/action.yaml
+++ b/action.yaml
@@ -1,17 +1,17 @@
-name: akuity-bookkeeper
+name: kargo-render
 description: Publish rendered manifests to an environment branch
 inputs:
   personalAccessToken:
-    description: A personal access token that allows Bookkeeper to write to your repository
+    description: A personal access token that allows Kargo Render to write to your repository
     required: true
   targetBranch:
     description: The environment branch for which you want to render manifests
     required: true
   allowEmpty:
-    description: Whether to allow rendered manifests to be empty. If false this is disallowed as a safeguard against scenarios where a bug of any kind might otherwise cause Bookkeeper to wipe out the contents of the target branch in error.
+    description: Whether to allow rendered manifests to be empty. If false this is disallowed as a safeguard against scenarios where a bug of any kind might otherwise cause Kargo Render to wipe out the contents of the target branch in error.
     required: false
     default: 'false'
 runs:
   using: docker
-  image: docker://ghcr.io/akuity/bookkeeper:v0.1.0-rc.24
-  entrypoint: bookkeeper-action
+  image: docker://ghcr.io/akuity/kargo-render:v0.1.0-rc.25
+  entrypoint: kargo-render-action

--- a/branches.go
+++ b/branches.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"fmt"
@@ -8,11 +8,11 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
-	"github.com/akuity/bookkeeper/internal/file"
+	"github.com/akuity/kargo-render/internal/file"
 )
 
 // branchMetadata encapsulates details about an environment-specific branch for
-// internal use by Bookkeeper.
+// internal use by Kargo Render.
 type branchMetadata struct {
 	// SourceCommit ia a back-reference to the specific commit in the repository's
 	// default branch (i.e. main or master) from which the manifests stored in
@@ -24,12 +24,12 @@ type branchMetadata struct {
 }
 
 // loadBranchMetadata attempts to load BranchMetadata from a
-// .bookkeeper/metadata.yaml file relative to the specified directory. If no
+// .kargo-render/metadata.yaml file relative to the specified directory. If no
 // such file is found a nil result is returned.
 func loadBranchMetadata(repoPath string) (*branchMetadata, error) {
 	path := filepath.Join(
 		repoPath,
-		".bookkeeper",
+		".kargo-render",
 		"metadata.yaml",
 	)
 	if exists, err := file.Exists(path); err != nil {
@@ -50,9 +50,9 @@ func loadBranchMetadata(repoPath string) (*branchMetadata, error) {
 }
 
 // writeBranchMetadata attempts to marshal the provided BranchMetadata and write
-// it to a .bookkeeper/metadata.yaml file relative to the specified directory.
+// it to a .kargo-render/metadata.yaml file relative to the specified directory.
 func writeBranchMetadata(md branchMetadata, repoPath string) error {
-	bkDir := filepath.Join(repoPath, ".bookkeeper")
+	bkDir := filepath.Join(repoPath, ".kargo-render")
 	// Ensure the existence of the directory
 	if err := os.MkdirAll(bkDir, 0755); err != nil {
 		return errors.Wrapf(err, "error ensuring existence of directory %q", bkDir)
@@ -68,7 +68,7 @@ func writeBranchMetadata(md branchMetadata, repoPath string) error {
 	)
 }
 
-func switchToTargetBranch(rc renderRequestContext) error {
+func switchToTargetBranch(rc requestContext) error {
 	logger := rc.logger.WithField("targetBranch", rc.request.TargetBranch)
 
 	// Check if the target branch exists on the remote
@@ -108,7 +108,7 @@ func switchToTargetBranch(rc renderRequestContext) error {
 	return nil
 }
 
-func switchToCommitBranch(rc renderRequestContext) (string, error) {
+func switchToCommitBranch(rc requestContext) (string, error) {
 	logger := rc.logger.WithField("targetBranch", rc.request.TargetBranch)
 
 	var commitBranch string
@@ -119,9 +119,9 @@ func switchToCommitBranch(rc renderRequestContext) (string, error) {
 		)
 	} else {
 		if rc.target.branchConfig.PRs.UseUniqueBranchNames {
-			commitBranch = fmt.Sprintf("prs/bookkeeper/%s", rc.request.id)
+			commitBranch = fmt.Sprintf("prs/kargo-render/%s", rc.request.id)
 		} else {
-			commitBranch = fmt.Sprintf("prs/bookkeeper/%s", rc.request.TargetBranch)
+			commitBranch = fmt.Sprintf("prs/kargo-render/%s", rc.request.TargetBranch)
 		}
 		logger = logger.WithField("commitBranch", commitBranch)
 		logger.Debug("changes will be PR'ed to the target branch")

--- a/branches_test.go
+++ b/branches_test.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"os"
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/bookkeeper/internal/file"
+	"github.com/akuity/kargo-render/internal/file"
 )
 
 func TestLoadBranchMetadata(t *testing.T) {
@@ -33,7 +33,7 @@ func TestLoadBranchMetadata(t *testing.T) {
 			setup: func() string {
 				repoDir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
-				bkDir := filepath.Join(repoDir, ".bookkeeper")
+				bkDir := filepath.Join(repoDir, ".kargo-render")
 				err = os.Mkdir(bkDir, 0755)
 				require.NoError(t, err)
 				err = os.WriteFile(
@@ -54,7 +54,7 @@ func TestLoadBranchMetadata(t *testing.T) {
 			setup: func() string {
 				repoDir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
-				bkDir := filepath.Join(repoDir, ".bookkeeper")
+				bkDir := filepath.Join(repoDir, ".kargo-render")
 				err = os.Mkdir(bkDir, 0755)
 				require.NoError(t, err)
 				err = os.WriteFile(
@@ -89,7 +89,7 @@ func TestWriteBranchMetadata(t *testing.T) {
 	)
 	require.NoError(t, err)
 	exists, err :=
-		file.Exists(filepath.Join(repoDir, ".bookkeeper", "metadata.yaml"))
+		file.Exists(filepath.Join(repoDir, ".kargo-render", "metadata.yaml"))
 	require.NoError(t, err)
 	require.True(t, exists)
 }

--- a/cmd/action/action.go
+++ b/cmd/action/action.go
@@ -8,8 +8,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/akuity/bookkeeper"
-	"github.com/akuity/bookkeeper/internal/version"
+	render "github.com/akuity/kargo-render"
+	"github.com/akuity/kargo-render/internal/version"
 )
 
 func Run() {
@@ -27,16 +27,16 @@ func Run() {
 	logger.WithFields(log.Fields{
 		"version": version.Version,
 		"commit":  version.GitCommit,
-	}).Info("Starting Bookkeeper Action")
+	}).Info("Starting Kargo Render Action")
 
 	req, err := request()
 	if err != nil {
 		logger.Fatal(err)
 	}
 
-	res, err := bookkeeper.NewService(
-		&bookkeeper.ServiceOptions{
-			LogLevel: bookkeeper.LogLevel(logger.Level),
+	res, err := render.NewService(
+		&render.ServiceOptions{
+			LogLevel: render.LogLevel(logger.Level),
 		},
 	).RenderManifests(context.Background(), req)
 	if err != nil {
@@ -44,22 +44,22 @@ func Run() {
 	}
 
 	switch res.ActionTaken {
-	case bookkeeper.ActionTakenNone:
+	case render.ActionTakenNone:
 		fmt.Println(
 			"\nThis request would not change any state. No action was taken.",
 		)
-	case bookkeeper.ActionTakenOpenedPR:
+	case render.ActionTakenOpenedPR:
 		fmt.Printf(
 			"\nOpened PR %s\n",
 			res.PullRequestURL,
 		)
-	case bookkeeper.ActionTakenPushedDirectly:
+	case render.ActionTakenPushedDirectly:
 		fmt.Printf(
 			"\nCommitted %s to branch %s\n",
 			res.CommitID,
 			req.TargetBranch,
 		)
-	case bookkeeper.ActionTakenUpdatedPR:
+	case render.ActionTakenUpdatedPR:
 		fmt.Printf(
 			"\nUpdated an existing PR to %s\n",
 			req.TargetBranch,

--- a/cmd/action/logger.go
+++ b/cmd/action/logger.go
@@ -1,5 +1,5 @@
 package action
 
-import libLog "github.com/akuity/bookkeeper/internal/log"
+import libLog "github.com/akuity/kargo-render/internal/log"
 
 var logger = libLog.LoggerOrDie()

--- a/cmd/action/request.go
+++ b/cmd/action/request.go
@@ -3,13 +3,13 @@ package action
 import (
 	"fmt"
 
-	"github.com/akuity/bookkeeper"
-	libOS "github.com/akuity/bookkeeper/internal/os"
+	render "github.com/akuity/kargo-render"
+	libOS "github.com/akuity/kargo-render/internal/os"
 )
 
-func request() (bookkeeper.RenderRequest, error) {
-	req := bookkeeper.RenderRequest{
-		RepoCreds: bookkeeper.RepoCredentials{
+func request() (render.Request, error) {
+	req := render.Request{
+		RepoCreds: render.RepoCredentials{
 			Username: "git",
 		},
 		Images: libOS.GetStringSliceFromEnvVar("INPUT_IMAGES", nil),

--- a/cmd/action/request_test.go
+++ b/cmd/action/request_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/bookkeeper"
+	render "github.com/akuity/kargo-render"
 )
 
 func TestRequest(t *testing.T) {
@@ -22,9 +22,9 @@ func TestRequest(t *testing.T) {
 		testImage1 = "krancour/foo:blue"
 		testImage2 = "krancour/foo:green"
 	)
-	testReq := bookkeeper.RenderRequest{
+	testReq := render.Request{
 		RepoURL: fmt.Sprintf("https://github.com/%s", testRepo),
-		RepoCreds: bookkeeper.RepoCredentials{
+		RepoCreds: render.RepoCredentials{
 			Username: "git",
 			Password: "12345", // Like something an idiot would use for their luggage
 		},
@@ -35,11 +35,11 @@ func TestRequest(t *testing.T) {
 	testCases := []struct {
 		name       string
 		setup      func()
-		assertions func(bookkeeper.RenderRequest, error)
+		assertions func(render.Request, error)
 	}{
 		{
 			name: "GITHUB_REPOSITORY not specified",
-			assertions: func(_ bookkeeper.RenderRequest, err error) {
+			assertions: func(_ render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "GITHUB_REPOSITORY")
@@ -50,7 +50,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("GITHUB_REPOSITORY", testRepo)
 			},
-			assertions: func(_ bookkeeper.RenderRequest, err error) {
+			assertions: func(_ render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "INPUT_PERSONALACCESSTOKEN")
@@ -61,7 +61,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("INPUT_PERSONALACCESSTOKEN", testReq.RepoCreds.Password)
 			},
-			assertions: func(_ bookkeeper.RenderRequest, err error) {
+			assertions: func(_ render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "GITHUB_SHA")
@@ -72,7 +72,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("GITHUB_SHA", testReq.Ref)
 			},
-			assertions: func(_ bookkeeper.RenderRequest, err error) {
+			assertions: func(_ render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "INPUT_TARGETBRANCH")
@@ -86,7 +86,7 @@ func TestRequest(t *testing.T) {
 					"INPUT_IMAGES",
 					fmt.Sprintf("%s,%s", testImage1, testImage2))
 			},
-			assertions: func(req bookkeeper.RenderRequest, err error) {
+			assertions: func(req render.Request, err error) {
 				require.NoError(t, err)
 				require.Equal(t, testReq, req)
 			},

--- a/cmd/cli/root_cmd.go
+++ b/cmd/cli/root_cmd.go
@@ -9,12 +9,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var desc = "Bookkeeper renders environment-specific manifests into " +
+var desc = "Kargo Render renders environment-specific manifests into " +
 	"environment-specific branches of your gitops repos"
 
 func newRootCommand() (*cobra.Command, error) {
 	command := &cobra.Command{
-		Use:              "bookkeeper",
+		Use:              "kargo-render",
 		Short:            desc,
 		Long:             desc,
 		PersistentPreRun: persistentPreRun,
@@ -40,7 +40,7 @@ func persistentPreRun(cmd *cobra.Command, _ []string) {
 			case flagRepoPassword, flagRepoUsername:
 				if !flag.Changed {
 					envVarName := fmt.Sprintf(
-						"BOOKKEEPER_%s",
+						"KARGO_RENDER_%s",
 						strings.ReplaceAll(
 							strings.ToUpper(flag.Name),
 							"-",

--- a/cmd/cli/version_cmd.go
+++ b/cmd/cli/version_cmd.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/akuity/bookkeeper/internal/version"
+	"github.com/akuity/kargo-render/internal/version"
 )
 
 func newVersionCommand() *cobra.Command {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,11 +6,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/akuity/bookkeeper/cmd/action"
-	"github.com/akuity/bookkeeper/cmd/cli"
+	"github.com/akuity/kargo-render/cmd/action"
+	"github.com/akuity/kargo-render/cmd/cli"
 )
 
-const binaryNameEnvVar = "BOOKKEEPER_BINARY_NAME"
+// false positive for "G101: Potential hardcoded credentials"
+const binaryNameEnvVar = "KARGO_RENDER_BINARY_NAME" // nolint: gosec
 
 func main() {
 	binaryName := filepath.Base(os.Args[0])
@@ -19,9 +20,9 @@ func main() {
 	}
 
 	switch binaryName {
-	case "bookkeeper":
+	case "kargo-render":
 		cli.Run()
-	case "bookkeeper-action":
+	case "kargo-render-action":
 		action.Run()
 	default:
 		log.Fatalf("unrecognized component name %q", binaryName)

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"encoding/json"
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/bookkeeper/internal/helm"
-	"github.com/akuity/bookkeeper/internal/kustomize"
-	"github.com/akuity/bookkeeper/internal/ytt"
+	"github.com/akuity/kargo-render/internal/helm"
+	"github.com/akuity/kargo-render/internal/kustomize"
+	"github.com/akuity/kargo-render/internal/ytt"
 )
 
 func TestLoadRepoConfig(t *testing.T) {
@@ -25,7 +25,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				dir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
 				err = os.WriteFile(
-					filepath.Join(dir, "Bookfile.json"),
+					filepath.Join(dir, "kargo-render.json"),
 					[]byte("bogus"),
 					0600,
 				)
@@ -37,7 +37,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				require.Contains(
 					t,
 					err.Error(),
-					"error normalizing and validating Bookkeeper configuration",
+					"error normalizing and validating Kargo Render configuration",
 				)
 			},
 		},
@@ -47,7 +47,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				dir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
 				err = os.WriteFile(
-					filepath.Join(dir, "Bookfile.yaml"),
+					filepath.Join(dir, "kargo-render.yaml"),
 					[]byte("bogus"),
 					0600,
 				)
@@ -59,7 +59,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				require.Contains(
 					t,
 					err.Error(),
-					"error normalizing and validating Bookkeeper configuration",
+					"error normalizing and validating Kargo Render configuration",
 				)
 			},
 		},
@@ -69,7 +69,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				dir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
 				err = os.WriteFile(
-					filepath.Join(dir, "Bookfile.json"),
+					filepath.Join(dir, "kargo-render.json"),
 					[]byte(`{"configVersion": "v1alpha1"}`),
 					0600,
 				)
@@ -86,7 +86,7 @@ func TestLoadRepoConfig(t *testing.T) {
 				dir, err := os.MkdirTemp("", "")
 				require.NoError(t, err)
 				err = os.WriteFile(
-					filepath.Join(dir, "Bookfile.yaml"),
+					filepath.Join(dir, "kargo-render.yaml"),
 					[]byte("configVersion: v1alpha1"),
 					0600,
 				)

--- a/context.go
+++ b/context.go
@@ -1,14 +1,14 @@
-package bookkeeper
+package render
 
 import (
 	log "github.com/sirupsen/logrus"
 
-	"github.com/akuity/bookkeeper/pkg/git"
+	"github.com/akuity/kargo-render/pkg/git"
 )
 
-type renderRequestContext struct {
+type requestContext struct {
 	logger       *log.Entry
-	request      RenderRequest
+	request      Request
 	repo         git.Repo
 	source       sourceContext
 	intermediate intermediateContext

--- a/docs/docs/10-overview.md
+++ b/docs/docs/10-overview.md
@@ -1,55 +1,57 @@
 ---
 slug: /
 title: Overview
-description: What is Bookkeeper?
+description: What is Kargo Render?
 ---
 
-# What is Bookkeeper?
+# What is Kargo Render?
 
-Bookkeeper helps Kubernetes users incorporate the environment branches pattern
+Kargo Render is a sub-project of [Kargo](https://github.com/akuity/kargo)
+that helps Kubernetes users incorporate the environment branches pattern
 into their [GitOps](https://opengitops.dev/) practice. There are numerous
 benefits to this pattern, which you can read about in detail
 [here](./environment-branches). If you're already familiar with this pattern and
 convinced of its benefits, dive right into the next section to get started!
 
 :::caution
-Bookkeeper is highly experimental at this time and breaking changes should be
+Kargo Render is highly experimental at this time and breaking changes should be
 anticipated between pre-GA minor releases.
 :::
 
 ## What you need to know
 
-Bookkeeper does _one thing:_ It uses your preferred configuration management
+Kargo Render does _one thing:_ It uses your preferred configuration management
 tool and some simple rules you define to render configuration from the default
 branch (e.g. `main`) of a remote GitOps repository into plain manifests that it
 stores in environment-specific branches of the same repository.
 
-When invoking Bookkeeper, you only need to specify the URL of the GitOps
+When invoking Kargo Render, you only need to specify the URL of the GitOps
 repository, appropriate credentials, and the name of the environment branch for
-which you wish to render and store manifests. Bookkeeper does the rest and you
+which you wish to render and store manifests. Kargo Render does the rest and you
 can point applicable configuration of your preferred GitOps-enabled CD platform
 at the environment branch.
 
 ## Getting started
 
-1. Bookkeeper can be integrated into your GitOps practice in a variety of ways.
-   Regardless of your entrypoint into its functionality, it relies on a
-   common bit of configuration -- `Bookfile.yaml`. Read more about that
+1. Kargo Render can be integrated into your GitOps practice in a variety of
+   ways. Regardless of your entrypoint into its functionality, it relies on a
+   common bit of configuration -- `kargo-render.yaml`. Read more about that
    [here](./how-to-guides/configuration).
 
-1. Once you've configured Bookkeeper, you have several options for how to
+1. Once you've configured Kargo Render, you have several options for how to
    utilize it. Skip right to the how-to section that best addresses your use
    case.
 
     * [GitHub Actions](./how-to-guides/github-actions): Start here if you want
-      to incorporate Bookkeeper into workflows powered by GitHub Actions.
+      to incorporate Kargo Render into workflows powered by GitHub Actions.
 
     * [Docker image](./how-to-guides/docker-image): Start here if you want to
-      incorporate Bookkeeper into workflows in _any other_ container-enabled
+      incorporate Kargo Render into workflows in _any other_ container-enabled
       automation platform. This is also the easiest option for experimenting
-      with Bookkeeper locally!
+      with Kargo Render locally!
 
     * [Go module](./how-to-guides/go-module): Start here if you want to
-      integrate with Bookkeeper programmatically using [Go](https://go.dev/)
+      integrate with Kargo Render programmatically using [Go](https://go.dev/)
       code. This is especially relevant for developers looking to build more
-      sophisticated GitOps tools on top of a foundation provided by Bookkeeper.
+      sophisticated GitOps tools on top of a foundation provided by Kargo
+      Render.

--- a/docs/docs/20-environment-branches.md
+++ b/docs/docs/20-environment-branches.md
@@ -5,7 +5,7 @@ description: What are environment branches?
 
 # What are environment branches?
 
-Understanding the _environment branches_ pattern at the heart of Bookkeeper
+Understanding the _environment branches_ pattern at the heart of Kargo Render
 begins with understanding some common difficulties encountered by
 [GitOps](https://opengitops.dev/) practitioners.
 
@@ -66,7 +66,7 @@ For any application, this pattern:
 
 Despite its many advantages, the environment branches pattern can be onerous
 to implement because it requires new automation to continuously render
-changes to your `main` branch into your environment branches. Bookkeeper's
+changes to your `main` branch into your environment branches. Kargo Render's
 singular goal is to answer those difficulties with an intuitive tool that puts
 the benefits of the environment branches pattern easily within reach for all
 GitOps practitioners.

--- a/docs/docs/30-how-to-guides/10-configuration.mdx
+++ b/docs/docs/30-how-to-guides/10-configuration.mdx
@@ -1,18 +1,18 @@
 ---
 title: Configuration
-description: Configuring Bookkeeper
+description: Configuring Kargo Render
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Configuring Bookkeeper
+# Configuring Kargo Render
 
-Bookkeeper is configured using a file named `Bookfile.yaml`, which should be
-stored at the root of the default branch of your GitOps repository.
+Kargo Render is configured using a file named `kargo-render.yaml`, which should
+be stored at the root of the default branch of your GitOps repository.
 
-The role of `Bookfile.yaml` is simply to enumerate your environment branches,
-and for each, specify:
+The role of `kargo-render.yaml` is simply to enumerate your environment
+branches, and for each, specify:
 
 * Which configuration management tools to use in rendering that environment
   branch -- and what the inputs to those tools are.
@@ -48,11 +48,11 @@ Understanding these two perspectives is important insofar as it impacts how a
 team is likely to organize their GitOps repositories.
 
 A team with an application-centric approach is likely to use a GitOps repository
-_per application_. Each Bookkeeper-managed environment branch within that
+_per application_. Each Kargo Render-managed environment branch within that
 repository will contain environment-specific manifests for the one application.
 In contrast, a team with an environment-centric approach is likely to include
 configuration for multiple applications in a single GitOps repository. Each
-Bookkeeper-managed environment branch within that repository will contain
+Kargo Render-managed environment branch within that repository will contain
 environment-specific manifests for multiple applications.
 
 Ultimately, the fundamental difference between the two approaches is whether a
@@ -62,7 +62,7 @@ examples that follow will involve _two_ applications -- `foo` and `bar`. When we
 render manifests for an environment branch, we wish to render manifests for
 _both_ apps.
 
-<Tabs groupId="bookfile">
+<Tabs groupId="kargo-render">
 
 <TabItem value="kustomize" label="Kustomize">
 
@@ -270,7 +270,7 @@ environment branch. Paths and other values for each environment were
 consistently a function of the environment's name. This is an obvious
 [DRY violation](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-To keep configuration more succinct, Bookkeeper supports matching environment
+To keep configuration more succinct, Kargo Render supports matching environment
 branches with applicable configuration using patterns (i.e. regular
 expressions). Capture groups can be used in those patterns to extract meaningful
 information, such as environment name, and paths that reference those capture
@@ -279,7 +279,7 @@ groups will be expanded accordingly.
 The following examples are equivalent to our initial examples, but are
 considerably more succinct:
 
-<Tabs groupId="dry-bookfile">
+<Tabs groupId="dry-kargo-render">
 
 <TabItem value="kustomize" label="Kustomize">
 
@@ -365,7 +365,7 @@ specific to any configuration management tool.
 
 ### Pull requests
 
-For any environment branch, you can specify that Bookkeeper should open pull
+For any environment branch, you can specify that Kargo Render should open pull
 requests for changes to that branch instead of committing those changes
 directly. (Committing changes directly is the default behavior.) This is an
 effective method of creating opportunities for manifest changes to be reviewed
@@ -431,8 +431,8 @@ branchConfigs:
 ### Combining manifests
 
 For any app configuration within an environment branch, you can specify that
-Bookkeeper should combine all Kubernetes resources into a single manifest file
-(named `all.yaml`). When not enabled (the default) Bookkeeper produces a
+Kargo Render should combine all Kubernetes resources into a single manifest file
+(named `all.yaml`). When not enabled (the default) Kargo Render produces a
 separate manifest file named `<resource name>-<resource type>` for every
 Kubernetes resource. Enabling this or not is strictly a matter of preference.
 
@@ -452,8 +452,8 @@ branchConfigs:
 
 ## Convention over configuration
 
-In the absence of a `Bookfile.yaml` file at the root of the default branch,
-Bookkeeper will assume:
+In the absence of a `kargo-render.yaml` file at the root of the default branch,
+Kargo Render will assume:
 
 * You are using [Kustomize](https://kustomize.io/) for configuration management.
 
@@ -471,5 +471,5 @@ Bookkeeper will assume:
 * Rendered manifests will be stored in the `app/` directory of the environment
   branches.
 
-If deemed acceptable, these assumptions permit Bookkeeper to be used without any
-configuration at all.
+If deemed acceptable, these assumptions permit Kargo Render to be used without
+any configuration at all.

--- a/docs/docs/30-how-to-guides/20-github-actions.md
+++ b/docs/docs/30-how-to-guides/20-github-actions.md
@@ -1,15 +1,15 @@
 ---
 title: GitHub Actions
-description: Using Bookkeeper with GitHub Actions
+description: Using Kargo Render with GitHub Actions
 ---
 
-# Using Bookkeeper with GitHub Actions
+# Using Kargo Render with GitHub Actions
 
-If you are integrating Bookkeeper into workflows that are implemented via GitHub
-Actions, Bookkeeper can be run as an action.
+If you are integrating Kargo Render into workflows that are implemented via
+GitHub Actions, Kargo Render can be run as an action.
 
 :::info
-The Bookkeeper action utilizes the official Bookkeeper Docker image and
+The Kargo Render action utilizes the official Kargo Render Docker image and
 therefore has guaranteed access to compatible versions of
 Git, Helm, Kustomize, and ytt, which are included on that image.
 :::
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Render manifests
-      uses: akuity/akuity-bookkeeper@v0.1.0-rc.21
+      uses: akuity/akuity-kargo-render@v0.1.0-rc.25
       with:
         personalAccessToken: ${{ secrets.GITHUB_TOKEN }}
         targetBranch: env/test

--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -1,25 +1,25 @@
 ---
 title: Docker image
-description: Using Bookkeeper's Docker image
+description: Using Kargo Render's Docker image
 ---
 
-# Using Bookkeeper's Docker image
+# Using Kargo Render's Docker image
 
-If you are integrating Bookkeeper into automated processes that are implemented
-with something other than GitHub Actions and those processes permit execution of
-commands within a Docker container (much as a GitHub action does), then
-utilizing the official Bookkeeper Docker image and the CLI found therein is a
-convenient option.
+If you are integrating Kargo Render into automated processes that are
+implemented with something other than GitHub Actions and those processes permit
+execution of commands within a Docker container (much as a GitHub action does),
+then utilizing the official Kargo Render Docker image and the CLI found therein
+is a convenient option.
 
 As long as Docker is installed on your system, using this image is also the
-easiest option for experimenting locally with Bookkeeper!
+easiest option for experimenting locally with Kargo Render!
 
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/bookkeeper:v0.1.0-rc.21 \
-  bookkeeper render \
-  --repo https://github.com/<your GitHub handle>/bookkeeper-demo-deploy \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.25 \
+  kargo-render render \
+  --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \
   --repo-password <a GitHub personal access token> \
   --target-branch env/dev
@@ -27,22 +27,22 @@ docker run -it ghcr.io/akuity/bookkeeper:v0.1.0-rc.21 \
 
 :::tip
 Although the exact procedure for emulating the example above will vary from one
-automation platform to the next, the Bookkeeper image should permit you to
-integrate Bookkeeper with a broad range of automation platforms including, but
+automation platform to the next, the Kargo Render image should permit you to
+integrate Kargo Render with a broad range of automation platforms including, but
 not limited to, popular choices such as [CircleCI](https://circleci.com/) or
 [Travis CI](https://www.travis-ci.com/).
 :::
 
 :::caution
-The `bookkeeper` CLI is not designed to be run anywhere except within a
-container based on the official Bookkeeper image. The official Bookkeeper image
-provides compatible versions of Kustomize, ytt, and Helm that cannot be
+The `kargo-render` CLI is not designed to be run anywhere except within a
+container based on the official Kargo Render image. The official Kargo Render
+image provides compatible versions of Kustomize, ytt, and Helm that cannot be
 guaranteed to exist on other systems.
 :::
 
 :::tip
-If you're using Bookkeeper's [Go module](./go-module) to interact
-programmatically with Bookkeeper, you might _also_ consider utilizing the
-Bookkeeper Docker image as a base image for your own software since it will
+If you're using Kargo Render's [Go module](./go-module) to interact
+programmatically with Kargo Render, you might _also_ consider utilizing the
+Kargo Render Docker image as a base image for your own software since it will
 guarantee the existence of compatible versions of Kustomize, ytt, and Helm. 
 :::

--- a/docs/docs/30-how-to-guides/40-go-module.md
+++ b/docs/docs/30-how-to-guides/40-go-module.md
@@ -1,37 +1,37 @@
 ---
 title: Go module
-description: Using Bookkeeper's Go module
+description: Using Kargo Render's Go module
 ---
 
-# Using Bookkeeper's Go module
+# Using Kargo Render's Go module
 
-Bookkeeper's functionality is available as a [Go](https://go.dev/) module.
+Kargo Render's functionality is available as a [Go](https://go.dev/) module.
 
 To add the module to your project:
 
 ```shell
-go get github.com/akuity/bookkeeper
+go get github.com/akuity/kargo-render
 ```
 
-Then instantiate an implementation of the `bookkeeper.Service` interface and
+Then instantiate an implementation of the `render.Service` interface and
 invoke the `RenderManifests()` function:
 
 ```golang
-import "github.com/akuity/bookkeeper"
+import "github.com/akuity/kargo-render"
 
 // ...
 
-svc := bookkeeper.NewService(
-  &bookkeeper.ServiceOptions{
-    LogLevel: bookkeeper.LogLevelDebug,
+svc := render.NewService(
+  &render.ServiceOptions{
+    LogLevel: render.LogLevelDebug,
   },
 )
 
 res, err := svc.RenderManifests(
   context.Background(),
-  bookkeeper.RenderRequest{
+  render.RenderRequest{
     RepoURL: "https://<repo URL>",
-    RepoCreds: bookkeeper.RepoCredentials{
+    RepoCreds: render.RepoCredentials{
       Username: "<username>",
       Password: "<password or personal access token>",
     },
@@ -45,17 +45,18 @@ if err != nil {
 }
 ```
 
-Unless an error occurs, the response (`bookkeeper.RenderResponse`) from the call
-above will contain details of any commit or pull request created by Bookkeeper.
+Unless an error occurs, the response (`render.RenderResponse`) from the call
+above will contain details of any commit or pull request created by Kargo
+Render.
 
 :::tip
-If options are omitted from the call to `bookkeeper.NewService()` (e.g. `nil`
-is passed), the default log level is `bookkeeper.LogLevelError`.
+If options are omitted from the call to `render.NewService()` (e.g. `nil`
+is passed), the default log level is `render.LogLevelError`.
 :::
 
 :::tip
 Compatible binaries for Git, Kustomize, ytt, and Helm must be available when
-using this module. Consider using Bookkeeper's official Docker image as a base
+using this module. Consider using Kargo Render's official Docker image as a base
 image for your own software. This will ensure the availability of compatible
 binaries.
 :::

--- a/docs/docs/40-contributor-guide/10-hacking-on-kargo-render.md
+++ b/docs/docs/40-contributor-guide/10-hacking-on-kargo-render.md
@@ -1,22 +1,22 @@
 ---
-description: Hacking on Bookkeeper
+description: Hacking on Kargo Render
 ---
 
-# Hacking on Bookkeeper
+# Hacking on Kargo Render
 
-Bookkeeper is implemented in Go. For maximum productivity in your text editor or
-IDE, it is recommended that you have installed the latest stable releases of Go
-and applicable editor/IDE extensions, however, this is not strictly required to
-be successful.
+Kargo Render is implemented in Go. For maximum productivity in your text editor
+or IDE, it is recommended that you have installed the latest stable releases of
+Go and applicable editor/IDE extensions, however, this is not strictly required
+to be successful.
 
 ## Running tests
 
 In order to minimize the setup required to successfully apply small changes and
 in order to reduce the incidence of “it worked on my machine,” wherein changes
 that pass tests locally do not pass the same tests in CI due to environmental
-differences, Bookkeeper has made it trivial to execute tests within a container
-that is maximally similar to the containers that tests execute in during the
-continuous integration process.
+differences, Kargo Render has made it trivial to execute tests within a
+container that is maximally similar to the containers that tests execute in
+during the continuous integration process.
 
 To take advantage of this, you only need to have
 [Docker](https://docs.docker.com/engine/install/) and `make` installed.
@@ -58,7 +58,7 @@ installed locally.
 
 ## Building the image
 
-To build source into a Docker image that will be tagged as `bookkeeper:dev`,
+To build source into a Docker image that will be tagged as `kargo-render:dev`,
 execute the following:
 
 ```shell
@@ -66,8 +66,8 @@ make hack-build
 ```
 
 :::note
-Because Bookkeeper is dependent on compatible versions of Git, Kustomize, ytt,
+Because Kargo Render is dependent on compatible versions of Git, Kustomize, ytt,
 and Helm binaries, there is seldom, if ever, a reason to build or execute the
-Bookkeeper binaries outside the context of a container that provides those
+Kargo Render binaries outside the context of a container that provides those
 dependencies.
 :::

--- a/docs/docs/40-contributor-guide/20-signing-commits.md
+++ b/docs/docs/40-contributor-guide/20-signing-commits.md
@@ -4,7 +4,7 @@ description: Signing commits
 
 # Signing commits
 
-All commits merged into Bookkeeper's `main` branch MUST bear a DCO (Developer
+All commits merged into Kargo Render's `main` branch MUST bear a DCO (Developer
 Certificate of Origin) sign-off. This is a line placed at the end of a commit
 message containing a contributor’s “signature.” In adding this, the contributor
 certifies that they have the right to contribute the material in question.
@@ -34,7 +34,7 @@ Here are the steps to sign your work:
 
       If you work on multiple projects that require a DCO sign-off, you can
       configure your git client to use these settings globally instead of only
-      for Bookkeeper:
+      for Kargo Render:
 
       ```shell
       git config --global user.name <legal name>

--- a/docs/docs/40-contributor-guide/index.md
+++ b/docs/docs/40-contributor-guide/index.md
@@ -6,9 +6,9 @@ description: Contributor guide
 
 This contributor guide is intended as a comprehensive introduction for
 developers who are looking to get involved with contributing directly to the
-Bookkeeper project.
+Kargo Render project.
 
 This guide is decomposed into the following, high-level topics:
 
-* [Hacking on Bookkeeper](./10-hacking-on-bookkeeper.md)
+* [Hacking on Kargo Render](./10-hacking-on-kargo-render.md)
 * [Signing commits](./20-signing-commits.md)

--- a/docs/docs/50-roadmap.md
+++ b/docs/docs/50-roadmap.md
@@ -5,7 +5,7 @@ description: Roadmap
 # Roadmap
 
 :::caution
-Bookkeeper is highly experimental at this time and breaking changes should be
+Kargo Render is highly experimental at this time and breaking changes should be
 anticipated between pre-GA minor releases.
 :::
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,8 +7,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Bookkeeper Docs',
-  url: 'https://bookkeeper.akuity.io',
+  title: 'Kargo Render Docs',
+  url: 'https://kargo-render.akuity.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -61,9 +61,9 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       navbar: {
-        title: 'Bookkeeper Docs',
+        title: 'Kargo Render Docs',
         logo: {
-          alt: 'Bookkeeper Documentation',
+          alt: 'Kargo Render Documentation',
           src: 'img/akuity.png',
           href: '/',
           target: '_self',
@@ -75,7 +75,7 @@ const config = {
             position: 'left',
           },
           {
-            href: 'https://github.com/akuity/bookkeeper',
+            href: 'https://github.com/akuity/kargo-render',
             label: 'GitHub',
             position: 'right',
           },

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/akuity/bookkeeper
+module github.com/akuity/kargo-render
 
 go 1.20
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 
-	"github.com/akuity/bookkeeper/pkg/git"
+	"github.com/akuity/kargo-render/pkg/git"
 )
 
 func OpenPR(

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -1,6 +1,6 @@
 package helm
 
-import "github.com/akuity/bookkeeper/internal/file"
+import "github.com/akuity/kargo-render/internal/file"
 
 // Config encapsulates optional Helm configuration options.
 type Config struct {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/akuity/bookkeeper/internal/manifests"
+	"github.com/akuity/kargo-render/internal/manifests"
 )
 
 // Render delegates, in-process to the Argo CD repo server to render plain YAML

--- a/internal/kustomize/config.go
+++ b/internal/kustomize/config.go
@@ -1,6 +1,6 @@
 package kustomize
 
-import "github.com/akuity/bookkeeper/internal/file"
+import "github.com/akuity/kargo-render/internal/file"
 
 // Config encapsulates optional Kustomize configuration options.
 type Config struct {

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/akuity/bookkeeper/internal/manifests"
-	"github.com/akuity/bookkeeper/internal/strings"
+	"github.com/akuity/kargo-render/internal/manifests"
+	"github.com/akuity/kargo-render/internal/strings"
 )
 
 // Render delegates, in-process to the Argo CD repo server to render plain YAML

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"os"
@@ -8,7 +8,7 @@ import (
 
 func LoggerOrDie() *log.Logger {
 	logLevel := log.InfoLevel
-	logLevelStr := os.Getenv("BOOKKEEPER_LOG_LEVEL")
+	logLevelStr := os.Getenv("KARGO_RENDER_LOG_LEVEL")
 	if logLevelStr != "" {
 		var err error
 		if logLevel, err = log.ParseLevel(logLevelStr); err != nil {

--- a/internal/ytt/config.go
+++ b/internal/ytt/config.go
@@ -1,6 +1,6 @@
 package ytt
 
-import "github.com/akuity/bookkeeper/internal/file"
+import "github.com/akuity/kargo-render/internal/file"
 
 // Config encapsulates optional ytt configuration options.
 type Config struct {

--- a/internal/ytt/ytt.go
+++ b/internal/ytt/ytt.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os/exec"
 
-	libExec "github.com/akuity/bookkeeper/internal/exec"
+	libExec "github.com/akuity/kargo-render/internal/exec"
 )
 
 // Render shells out to the ytt binary to render the provided paths into plain

--- a/logging.go
+++ b/logging.go
@@ -1,8 +1,8 @@
-package bookkeeper
+package render
 
 import log "github.com/sirupsen/logrus"
 
-// LogLevel represents the level of detail logged by the Bookkeeper service's
+// LogLevel represents the level of detail logged by the Kargo Render service's
 // internal logger.
 type LogLevel log.Level
 
@@ -10,7 +10,7 @@ const (
 	// LogLevelDebug represents DEBUG level logging.
 	LogLevelDebug = LogLevel(log.DebugLevel)
 	// LogLevelInfo represents INFO level logging. This is the default for the
-	// Bookkeeper service when no LogLevel is explicitly specified.
+	// Kargo Render service when no LogLevel is explicitly specified.
 	LogLevelInfo = LogLevel(log.InfoLevel)
 	// LogLevelError represents ERROR level logging.
 	LogLevelError = LogLevel(log.ErrorLevel)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	libExec "github.com/akuity/bookkeeper/internal/exec"
+	libExec "github.com/akuity/kargo-render/internal/exec"
 )
 
 // RepoCredentials represents the credentials for connecting to a private git
@@ -337,13 +337,13 @@ func (r *repo) WorkingDir() string {
 // "store" (username/password-based) credential helper.
 func (r *repo) setupAuth(repoCreds RepoCredentials) error {
 	// Configure the git client
-	cmd := r.buildCommand("config", "--global", "user.name", "Bookkeeper")
+	cmd := r.buildCommand("config", "--global", "user.name", "Kargo Render")
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return errors.Wrapf(err, "error configuring git username")
 	}
 	cmd =
-		r.buildCommand("config", "--global", "user.email", "bookkeeper@akuity.io")
+		r.buildCommand("config", "--global", "user.email", "kargo-render@akuity.io")
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return errors.Wrapf(err, "error configuring git user email address")

--- a/prs.go
+++ b/prs.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"context"
@@ -7,11 +7,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/akuity/bookkeeper/internal/github"
-	"github.com/akuity/bookkeeper/pkg/git"
+	"github.com/akuity/kargo-render/internal/github"
+	"github.com/akuity/kargo-render/pkg/git"
 )
 
-func openPR(ctx context.Context, rc renderRequestContext) (string, error) {
+func openPR(ctx context.Context, rc requestContext) (string, error) {
 	commitMsgParts := strings.SplitN(rc.target.commit.message, "\n", 2)
 	var title string
 	if rc.target.branchConfig.PRs.UseUniqueBranchNames {

--- a/rendering.go
+++ b/rendering.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"context"
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/akuity/bookkeeper/internal/kustomize"
-	"github.com/akuity/bookkeeper/internal/strings"
+	"github.com/akuity/kargo-render/internal/kustomize"
+	"github.com/akuity/kargo-render/internal/strings"
 )
 
 var lastMileKustomizationBytes = []byte(
@@ -24,7 +24,7 @@ resources:
 
 func (s *service) preRender(
 	ctx context.Context,
-	rc renderRequestContext,
+	rc requestContext,
 	repoDir string,
 ) (map[string][]byte, error) {
 	logger := rc.logger
@@ -115,7 +115,7 @@ func (s *service) preRender(
 
 func renderLastMile(
 	ctx context.Context,
-	rc renderRequestContext,
+	rc requestContext,
 ) ([]string, map[string][]byte, error) {
 	logger := rc.logger
 

--- a/rendering_test.go
+++ b/rendering_test.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"context"
@@ -8,9 +8,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/bookkeeper/internal/helm"
-	"github.com/akuity/bookkeeper/internal/kustomize"
-	"github.com/akuity/bookkeeper/internal/ytt"
+	"github.com/akuity/kargo-render/internal/helm"
+	"github.com/akuity/kargo-render/internal/kustomize"
+	"github.com/akuity/kargo-render/internal/ytt"
 )
 
 func TestPreRender(t *testing.T) {
@@ -18,13 +18,13 @@ func TestPreRender(t *testing.T) {
 	fakeManifest := []byte("fake-manifest")
 	testCases := []struct {
 		name       string
-		rc         renderRequestContext
+		rc         requestContext
 		service    *service
 		assertions func(manifests map[string][]byte, err error)
 	}{
 		{
 			name: "error pre-rendering with helm",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -55,7 +55,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "success pre-rendering with helm",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -86,7 +86,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "error pre-rendering with ytt",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -111,7 +111,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "success pre-rendering with ytt",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -136,7 +136,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "error pre-rendering with kustomize",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -166,7 +166,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "success pre-rendering with kustomize",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{
@@ -196,7 +196,7 @@ func TestPreRender(t *testing.T) {
 		},
 		{
 			name: "safeguards against empty manifests",
-			rc: renderRequestContext{
+			rc: requestContext{
 				target: targetContext{
 					branchConfig: branchConfig{
 						AppConfigs: map[string]appConfig{

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "bookfile-schema.json",
+	"$id": "kargo-render-schema.json",
 
 	"definitions": {
 

--- a/service_test.go
+++ b/service_test.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/bookkeeper/internal/file"
+	"github.com/akuity/kargo-render/internal/file"
 )
 
 func TestNewService(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -1,31 +1,31 @@
-package bookkeeper
+package render
 
 // ActionTaken indicates what action, if any was taken in response to a
 // RenderRequest.
 type ActionTaken string
 
 const (
-	// ActionTakenNone represents the case where Bookkeeper responded
+	// ActionTakenNone represents the case where Kargo Render responded
 	// to a RenderRequest by, effectively, doing nothing. This occurs in cases
 	// where the fully rendered manifests that would have been written to the
 	// target branch do not differ from what is already present at the head of
 	// that branch.
 	ActionTakenNone ActionTaken = "NONE"
-	// ActionTakenOpenedPR represents the case where Bookkeeper responded to a
+	// ActionTakenOpenedPR represents the case where Kargo Render responded to a
 	// RenderRequest by opening a new pull request against the target branch.
 	ActionTakenOpenedPR ActionTaken = "OPENED_PR"
-	// ActionTakenPushedDirectly represents the case where Bookkeeper responded
+	// ActionTakenPushedDirectly represents the case where Kargo Render responded
 	// to a RenderRequest by pushing a new commit directly to the target branch.
 	ActionTakenPushedDirectly ActionTaken = "PUSHED_DIRECTLY"
-	// ActionTakenUpdatedPR represents the case where Bookkeeper responded to a
+	// ActionTakenUpdatedPR represents the case where Kargo Render responded to a
 	// RenderRequest by updating an existing PR.
 	ActionTakenUpdatedPR ActionTaken = "UPDATED_PR"
 )
 
-// RenderRequest is a request for Bookkeeper to render environment-specific
+// Request is a request for Kargo Render to render environment-specific
 // manifests from input in the  default branch of the repository specified by
 // RepoURL.
-type RenderRequest struct {
+type Request struct {
 	id string
 	// RepoURL is the URL of a remote GitOps repository.
 	RepoURL string `json:"repoURL,omitempty"`
@@ -44,13 +44,13 @@ type RenderRequest struct {
 	// manifests.
 	Images []string `json:"images,omitempty"`
 	// CommitMessage offers the opportunity to, optionally, override the first
-	// line of the commit message that Bookkeeper would normally generate.
+	// line of the commit message that Kargo Render would normally generate.
 	CommitMessage string `json:"commitMessage,omitempty"`
-	// AllowEmpty indicates whether or not Bookkeeper should allow the rendered
-	// manifests to be empty. If this is false (the default), Bookkeeper will
+	// AllowEmpty indicates whether or not Kargo Render should allow the rendered
+	// manifests to be empty. If this is false (the default), Kargo Render will
 	// return an error if the rendered manifests are empty. This is a safeguard
-	// against scenarios where a bug of any kind might otherwise cause Bookkeeper
-	// to wipe out the contents of the target branch in error.
+	// against scenarios where a bug of any kind might otherwise cause Kargo
+	// Render to wipe out the contents of the target branch in error.
 	AllowEmpty bool `json:"allowEmpty,omitempty"`
 }
 
@@ -70,9 +70,9 @@ type RepoCredentials struct {
 	Password string `json:"password,omitempty"`
 }
 
-// RenderResponse encapsulates details of a successful rendering of some
+// Response encapsulates details of a successful rendering of some
 // environment-specific manifests into an environment-specific branch.
-type RenderResponse struct {
+type Response struct {
 	ActionTaken ActionTaken `json:"actionTaken,omitempty"`
 	// CommitID is the ID (sha) of the commit to the environment-specific branch
 	// containing the rendered manifests. This is only set when the OpenPR field

--- a/validation.go
+++ b/validation.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"regexp"
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func validateAndCanonicalizeRequest(req RenderRequest) (RenderRequest, error) {
+func validateAndCanonicalizeRequest(req Request) (Request, error) {
 	req.RepoURL = strings.TrimSpace(req.RepoURL)
 	if req.RepoURL == "" {
 		return req, errors.New("validation failed: RepoURL is a required field")

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,4 +1,4 @@
-package bookkeeper
+package render
 
 import (
 	"testing"
@@ -9,23 +9,23 @@ import (
 func TestValidateAndCanonicalizeRequest(t *testing.T) {
 	testCases := []struct {
 		name       string
-		req        RenderRequest
-		assertions func(RenderRequest, error)
+		req        Request
+		assertions func(Request, error)
 	}{
 		{
 			name: "missing RepoURL",
-			req:  RenderRequest{},
-			assertions: func(req RenderRequest, err error) {
+			req:  Request{},
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "RepoURL is a required field")
 			},
 		},
 		{
 			name: "invalid RepoURL",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "foobar",
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -36,10 +36,10 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 		},
 		{
 			name: "missing Password",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "https://github.com/akuity/foobar",
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -50,21 +50,21 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 		},
 		{
 			name: "missing TargetBranch",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "https://github.com/akuity/foobar",
 				RepoCreds: RepoCredentials{
 					Password: "foobar",
 				},
 				Ref: "1abcdef2",
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "TargetBranch is a required field")
 			},
 		},
 		{
 			name: "invalid TargetBranch",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "https://github.com/akuity/foobar",
 				RepoCreds: RepoCredentials{
 					Password: "foobar",
@@ -72,14 +72,14 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 				Ref:          "1abcdef2",
 				TargetBranch: "env/dev*", // * is an invalid character
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "is an invalid branch name")
 			},
 		},
 		{
 			name: "empty string image",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "https://github.com/akuity/foobar",
 				RepoCreds: RepoCredentials{
 					Password: "foobar",
@@ -88,7 +88,7 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 				TargetBranch: "env/dev",
 				Images:       []string{""}, // no good
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -99,7 +99,7 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 		},
 		{
 			name: "validation succeeds",
-			req: RenderRequest{
+			req: Request{
 				RepoURL: "  https://github.com/akuity/foobar  ",
 				RepoCreds: RepoCredentials{
 					Password: "  foobar  ",
@@ -108,7 +108,7 @@ func TestValidateAndCanonicalizeRequest(t *testing.T) {
 				TargetBranch: "  refs/heads/env/dev  ",
 				Images:       []string{" akuity/some-image "}, // no good
 			},
-			assertions: func(req RenderRequest, err error) {
+			assertions: func(req Request, err error) {
 				require.NoError(t, err)
 				require.Equal(t, "https://github.com/akuity/foobar", req.RepoURL)
 				require.Equal(t, "foobar", req.RepoCreds.Password)


### PR DESCRIPTION
Fixes #181 

This PR renames the project to Kargo Render.

The new configuration file (previously `Bookfile.yaml`) is `kargo-render.yaml`.

New package name is `render`, so some exported types like `RenderRequest` and `RenderResponse` got renamed to avoid the so-called "stutter" of `render.RenderRequest`, etc.

There are no functional changes in this PR.

Some non-code follow-up work may be required -- corresponding changes to CodeCov, Netlify, etc.

